### PR TITLE
Add basic account controller with auth pages

### DIFF
--- a/projects/Controllers/AccountController.cs
+++ b/projects/Controllers/AccountController.cs
@@ -1,0 +1,137 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using projects.Models;
+using projects.Servises;
+using projects.ViewModels;
+
+namespace projects.Controllers
+{
+    public class AccountController : Controller
+    {
+        private readonly UserManager<User> _userManager;
+        private readonly SignInManager<User> _signInManager;
+        private readonly EmailSendler _emailSender;
+
+        public AccountController(UserManager<User> userManager,
+            SignInManager<User> signInManager,
+            EmailSendler emailSender)
+        {
+            _userManager = userManager;
+            _signInManager = signInManager;
+            _emailSender = emailSender;
+        }
+
+        [HttpGet]
+        [AllowAnonymous]
+        public IActionResult Register()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        [AllowAnonymous]
+        public async Task<IActionResult> Register(RegisterViewModel model)
+        {
+            if (!ModelState.IsValid)
+                return View(model);
+
+            var user = new User
+            {
+                Email = model.Email,
+                UserName = model.Nickname,
+                Login = model.Nickname,
+                IsConfirmed = true
+            };
+            var result = await _userManager.CreateAsync(user, model.Password);
+            if (result.Succeeded)
+            {
+                await _signInManager.SignInAsync(user, isPersistent: false);
+                return RedirectToAction("Index", "Home", new { area = "" });
+            }
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+            return View(model);
+        }
+
+        [HttpGet]
+        [AllowAnonymous]
+        public IActionResult Login(string? returnUrl = null)
+        {
+            ViewData["ReturnUrl"] = returnUrl;
+            return View();
+        }
+
+        [HttpPost]
+        [AllowAnonymous]
+        public async Task<IActionResult> Login(LoginViewModel model, string? returnUrl = null)
+        {
+            ViewData["ReturnUrl"] = returnUrl;
+            if (!ModelState.IsValid)
+                return View(model);
+
+            User? user = null;
+            if (model.EmailOrNickname.Contains('@'))
+            {
+                user = await _userManager.FindByEmailAsync(model.EmailOrNickname);
+            }
+            if (user == null)
+            {
+                user = await _userManager.FindByNameAsync(model.EmailOrNickname);
+            }
+            if (user == null)
+            {
+                ModelState.AddModelError(string.Empty, "Invalid login attempt.");
+                return View(model);
+            }
+
+            var result = await _signInManager.PasswordSignInAsync(user.UserName!, model.Password, model.RememberMe, lockoutOnFailure: false);
+            if (result.Succeeded)
+            {
+                if (string.IsNullOrEmpty(returnUrl))
+                    return RedirectToAction("Index", "Home", new { area = "" });
+                return LocalRedirect(returnUrl);
+            }
+            ModelState.AddModelError(string.Empty, "Invalid login attempt.");
+            return View(model);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Logout()
+        {
+            await _signInManager.SignOutAsync();
+            return RedirectToAction("Index", "Home", new { area = "" });
+        }
+
+        [HttpGet]
+        [AllowAnonymous]
+        public IActionResult ForgotPassword()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        [AllowAnonymous]
+        public async Task<IActionResult> ForgotPassword(ForgotPasswordViewModel model)
+        {
+            if (!ModelState.IsValid)
+                return View(model);
+
+            var user = await _userManager.FindByEmailAsync(model.Email);
+            if (user != null)
+            {
+                var newPassword = Guid.NewGuid().ToString("N").Substring(0, 8) + "!";
+                var token = await _userManager.GeneratePasswordResetTokenAsync(user);
+                var result = await _userManager.ResetPasswordAsync(user, token, newPassword);
+                if (result.Succeeded)
+                {
+                    await _emailSender.SendEmailAsync(model.Email, "New password", $"Your new password: {newPassword}");
+                }
+            }
+            ViewData["Message"] = "If the email exists, a new password was sent.";
+            return View();
+        }
+    }
+}

--- a/projects/Controllers/HomeController.cs
+++ b/projects/Controllers/HomeController.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace projects.Controllers
+{
+    public class HomeController : Controller
+    {
+        public IActionResult Index()
+        {
+            return Redirect("/");
+        }
+    }
+}

--- a/projects/Pages/Shared/_Layout.cshtml
+++ b/projects/Pages/Shared/_Layout.cshtml
@@ -27,6 +27,22 @@
                             <a class="nav-link text-dark" asp-area="" asp-page="/Privacy">Privacy</a>
                         </li>
                     </ul>
+                    <ul class="navbar-nav">
+                        @if (User.Identity?.IsAuthenticated ?? false)
+                        {
+                            <li class="nav-item">
+                                <form asp-controller="Account" asp-action="Logout" method="post" class="d-inline">
+                                    <button type="submit" class="nav-link btn btn-link">Logout</button>
+                                </form>
+                            </li>
+                        }
+                        else
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link" asp-controller="Account" asp-action="Login">Login</a>
+                            </li>
+                        }
+                    </ul>
                 </div>
             </div>
         </nav>

--- a/projects/Program.cs
+++ b/projects/Program.cs
@@ -12,12 +12,14 @@ namespace projects
 
             // Add services to the container.
             builder.Services.AddRazorPages();
+            builder.Services.AddControllersWithViews();
 
             var connectionString = builder.Configuration.GetConnectionString("DefaultConnection");
             builder.Services.AddDbContext<projects.Models.ApplicationDbContext>(options =>
                 options.UseNpgsql(connectionString));
 
             builder.Services.AddScoped<projects.Servises.MatchService>();
+            builder.Services.AddTransient<projects.Servises.EmailSendler>();
             IdentityBuilder identityBuilder = builder.Services.AddDefaultIdentity<User>(options => options.SignIn.RequireConfirmedAccount = false).AddEntityFrameworkStores<ApplicationDbContext>();
 
             var app = builder.Build();
@@ -38,6 +40,9 @@ namespace projects
             app.UseAuthorization();
 
             app.MapStaticAssets();
+            app.MapControllerRoute(
+                name: "default",
+                pattern: "{controller=Home}/{action=Index}/{id?}");
             app.MapRazorPages()
                .WithStaticAssets();
 

--- a/projects/ViewModels/ForgotPasswordViewModel.cs
+++ b/projects/ViewModels/ForgotPasswordViewModel.cs
@@ -1,0 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace projects.ViewModels
+{
+    public class ForgotPasswordViewModel
+    {
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+    }
+}

--- a/projects/ViewModels/LoginViewModel.cs
+++ b/projects/ViewModels/LoginViewModel.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace projects.ViewModels
+{
+    public class LoginViewModel
+    {
+        [Required]
+        [Display(Name="Email or nickname")]
+        public string EmailOrNickname { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        public string Password { get; set; } = string.Empty;
+
+        [Display(Name="Remember me")]
+        public bool RememberMe { get; set; }
+    }
+}

--- a/projects/ViewModels/RegisterViewModel.cs
+++ b/projects/ViewModels/RegisterViewModel.cs
@@ -1,0 +1,23 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace projects.ViewModels
+{
+    public class RegisterViewModel
+    {
+        [Required]
+        [EmailAddress]
+        public string Email { get; set; } = string.Empty;
+
+        [Required]
+        public string Nickname { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        public string Password { get; set; } = string.Empty;
+
+        [Required]
+        [DataType(DataType.Password)]
+        [Display(Name = "Confirm password")]
+        public string ConfirmPassword { get; set; } = string.Empty;
+    }
+}

--- a/projects/Views/Account/ForgotPassword.cshtml
+++ b/projects/Views/Account/ForgotPassword.cshtml
@@ -1,0 +1,21 @@
+@model projects.ViewModels.ForgotPasswordViewModel
+@{
+    ViewData["Title"] = "Forgot password";
+}
+<h2>Forgot password</h2>
+@if (ViewData["Message"] != null)
+{
+    <p class="text-success">@ViewData["Message"]</p>
+}
+<form asp-action="ForgotPassword" method="post" class="mt-3">
+    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    <div class="form-floating mb-2">
+        <input asp-for="Email" class="form-control" />
+        <label asp-for="Email"></label>
+        <span asp-validation-for="Email" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Send new password</button>
+</form>
+@section Scripts {
+    <partial name="~/Pages/Shared/_ValidationScriptsPartial.cshtml" />
+}

--- a/projects/Views/Account/Login.cshtml
+++ b/projects/Views/Account/Login.cshtml
@@ -1,0 +1,29 @@
+@model projects.ViewModels.LoginViewModel
+@{
+    ViewData["Title"] = "Login";
+}
+<h2>Login</h2>
+<form asp-action="Login" method="post" class="mt-3">
+    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    <div class="form-floating mb-2">
+        <input asp-for="EmailOrNickname" class="form-control" />
+        <label asp-for="EmailOrNickname"></label>
+        <span asp-validation-for="EmailOrNickname" class="text-danger"></span>
+    </div>
+    <div class="form-floating mb-2">
+        <input asp-for="Password" type="password" class="form-control" />
+        <label asp-for="Password"></label>
+        <span asp-validation-for="Password" class="text-danger"></span>
+    </div>
+    <div class="form-check mb-2">
+        <input asp-for="RememberMe" class="form-check-input" />
+        <label asp-for="RememberMe" class="form-check-label"></label>
+    </div>
+    <button type="submit" class="btn btn-primary">Login</button>
+</form>
+<div class="mt-2">
+    <a asp-action="ForgotPassword">Забыли пароль?</a>
+</div>
+@section Scripts {
+    <partial name="~/Pages/Shared/_ValidationScriptsPartial.cshtml" />
+}

--- a/projects/Views/Account/Register.cshtml
+++ b/projects/Views/Account/Register.cshtml
@@ -1,0 +1,36 @@
+@model projects.ViewModels.RegisterViewModel
+@{
+    ViewData["Title"] = "Register";
+}
+<h2>Register</h2>
+<form asp-action="Register" method="post" class="mt-3">
+    <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+    <div class="form-floating mb-2">
+        <input asp-for="Email" class="form-control" />
+        <label asp-for="Email"></label>
+        <span asp-validation-for="Email" class="text-danger"></span>
+    </div>
+    <div class="form-floating mb-2">
+        <input asp-for="Nickname" class="form-control" />
+        <label asp-for="Nickname"></label>
+        <span asp-validation-for="Nickname" class="text-danger"></span>
+    </div>
+    <div class="form-floating mb-2">
+        <input asp-for="Password" type="password" class="form-control" id="Password" />
+        <label asp-for="Password"></label>
+        <span asp-validation-for="Password" class="text-danger"></span>
+    </div>
+    <div class="form-floating mb-2">
+        <input asp-for="ConfirmPassword" type="password" class="form-control" id="ConfirmPassword" />
+        <label asp-for="ConfirmPassword"></label>
+        <span asp-validation-for="ConfirmPassword" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Register</button>
+</form>
+<div class="mt-2">
+    <a asp-action="Login">Авторизация</a>
+</div>
+@section Scripts {
+    <partial name="~/Pages/Shared/_ValidationScriptsPartial.cshtml" />
+    <script src="~/js/passwordCheck.js"></script>
+}

--- a/projects/Views/_ViewImports.cshtml
+++ b/projects/Views/_ViewImports.cshtml
@@ -1,0 +1,2 @@
+@using projects
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/projects/Views/_ViewStart.cshtml
+++ b/projects/Views/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "_Layout";
+}

--- a/projects/wwwroot/js/passwordCheck.js
+++ b/projects/wwwroot/js/passwordCheck.js
@@ -1,0 +1,16 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const password = document.getElementById('Password');
+    const confirm = document.getElementById('ConfirmPassword');
+    if (!password || !confirm) return;
+
+    function validate() {
+        if (password.value !== confirm.value) {
+            confirm.setCustomValidity('Passwords do not match');
+        } else {
+            confirm.setCustomValidity('');
+        }
+    }
+
+    password.addEventListener('input', validate);
+    confirm.addEventListener('input', validate);
+});


### PR DESCRIPTION
## Summary
- add `AccountController` with register/login/forgot password features
- add view models and MVC views for register, login and reset password pages
- wire up navigation links in layout with logout button
- enable MVC controllers in `Program.cs`
- include JS for client-side password confirmation

## Testing
- `dotnet build projects/projects.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68560645d5d08323be90501986b43074