### PR TITLE
Integrate role seeding and identity setup

### DIFF
--- a/projects/Servises/AdminInitial.cs
+++ b/projects/Servises/AdminInitial.cs
@@ -5,7 +5,7 @@ namespace projects.Servises
 {
     public class AdminInitial
     {
-        public static async Task SeedAdminUser(RoleManager<IdentityRole<int>> roleManager, UserManager<User> userManager)
+        public static async Task SeedAdminUser(RoleManager<IdentityRole<Guid>> roleManager, UserManager<User> userManager)
         {
             try
             {
@@ -17,7 +17,7 @@ namespace projects.Servises
                 foreach (var roleName in roles)
                 {
                     if (await roleManager.FindByNameAsync(roleName) == null)
-                        await roleManager.CreateAsync(new IdentityRole<int>(roleName));
+                        await roleManager.CreateAsync(new IdentityRole<Guid>(roleName));
                 }
 
                 if (await userManager.FindByEmailAsync(adminEmail) == null)


### PR DESCRIPTION
## Summary
- integrate role creation and admin seed on startup
- customize identity password policy
- wire up UserService and response compression

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68560819cbf483239d5dc03cbfe6970c