### PR TITLE
Implement default user role and profile updates

### DIFF
--- a/projects/Controllers/AccountController.cs
+++ b/projects/Controllers/AccountController.cs
@@ -41,11 +41,14 @@ namespace projects.Controllers
                 Email = model.Email,
                 UserName = model.Nickname,
                 Login = model.Nickname,
-                IsConfirmed = true
+                DisplayName = model.Nickname,
+                IsConfirmed = true,
+                RoleName = "User"
             };
             var result = await _userManager.CreateAsync(user, model.Password);
             if (result.Succeeded)
             {
+                await _userManager.AddToRoleAsync(user, "User");
                 await _signInManager.SignInAsync(user, isPersistent: false);
                 return RedirectToAction("Index", "Home", new { area = "" });
             }

--- a/projects/Pages/Profile/Index.cshtml
+++ b/projects/Pages/Profile/Index.cshtml
@@ -11,8 +11,29 @@
 {
     <div>
         <img src="@Model.UserInfo.AvatarUrl" alt="Avatar" width="128" height="128" />
-        <p>Display Name: @Model.UserInfo.DisplayName</p>
-        <p>Email: @Model.UserInfo.Email</p>
+        <form method="post">
+            <div class="mb-3">
+                <label class="form-label">Display Name</label>
+                <input class="form-control" asp-for="Input.DisplayName" />
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Avatar URL</label>
+                <input class="form-control" asp-for="Input.AvatarUrl" />
+            </div>
+            <button type="submit" class="btn btn-primary">Save</button>
+        </form>
+        <p class="mt-3">Email: @Model.UserInfo.Email</p>
+        <p>
+            @if (Model.UserInfo.EmailConfirmed)
+            {
+                <span class="text-success">Email подтверждён</span>
+            }
+            else
+            {
+                <span class="text-danger">Email не подтверждён</span>
+                <button type="submit" formmethod="post" formaction="?handler=ConfirmEmail" class="btn btn-success ms-2">Подтвердить Email?</button>
+            }
+        </p>
         <p>Balance: @Model.UserInfo.Wallet?.Balance</p>
         <p>Premium Balance: @Model.UserInfo.Wallet?.PremiumBalance</p>
         <p>Total Wins: @Model.WinsCount</p>

--- a/projects/Pages/Profile/Index.cshtml.cs
+++ b/projects/Pages/Profile/Index.cshtml.cs
@@ -14,6 +14,14 @@ namespace projects.Pages.Profile
 
         public User? UserInfo { get; set; }
         public int WinsCount { get; set; }
+        [BindProperty]
+        public ProfileInput Input { get; set; } = new();
+
+        public class ProfileInput
+        {
+            public string? DisplayName { get; set; }
+            public string? AvatarUrl { get; set; }
+        }
 
         public IndexModel(ApplicationDbContext context, UserManager<User> userManager)
         {
@@ -36,7 +44,33 @@ namespace projects.Pages.Profile
             if (UserInfo != null)
             {
                 WinsCount = await _context.Matches.CountAsync(m => m.WinnerId == guid);
+                Input.DisplayName = UserInfo.DisplayName;
+                Input.AvatarUrl = UserInfo.AvatarUrl;
             }
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+                return RedirectToPage();
+
+            user.DisplayName = Input.DisplayName;
+            user.AvatarUrl = Input.AvatarUrl;
+            await _userManager.UpdateAsync(user);
+
+            return RedirectToPage();
+        }
+
+        public async Task<IActionResult> OnPostConfirmEmailAsync()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user != null && !user.EmailConfirmed)
+            {
+                user.EmailConfirmed = true;
+                await _userManager.UpdateAsync(user);
+            }
+            return RedirectToPage();
         }
     }
 }

--- a/projects/Pages/Shared/_Layout.cshtml
+++ b/projects/Pages/Shared/_Layout.cshtml
@@ -31,6 +31,9 @@
                         @if (User.Identity?.IsAuthenticated ?? false)
                         {
                             <li class="nav-item">
+                                <span class="nav-link fw-bold">@User.Identity?.Name</span>
+                            </li>
+                            <li class="nav-item">
                                 <form asp-controller="Account" asp-action="Logout" method="post" class="d-inline">
                                     <button type="submit" class="nav-link btn btn-link">Logout</button>
                                 </form>

--- a/projects/Program.cs
+++ b/projects/Program.cs
@@ -64,7 +64,7 @@ namespace projects
             using (var scope = app.Services.CreateScope())
             {
                 var roleManager = scope.ServiceProvider.GetRequiredService<RoleManager<IdentityRole<Guid>>>();
-                var roles = new[] { "Admin", "Manager", "Member" };
+                var roles = new[] { "Admin", "Manager", "User" };
                 foreach (var role in roles)
                 {
                     if (!await roleManager.RoleExistsAsync(role))

--- a/projects/Servises/AdminInitial.cs
+++ b/projects/Servises/AdminInitial.cs
@@ -12,7 +12,7 @@ namespace projects.Servises
                 string adminEmail = "admin@mail.ru";
                 string adminPassword = "123!A123";
                 string adminLogin = "AdminaSosok22";
-                var roles = new[] { "Admin", "Manager", "Member" };
+                var roles = new[] { "Admin", "Manager", "User" };
 
                 foreach (var roleName in roles)
                 {


### PR DESCRIPTION
## Summary
- seed `User` role
- assign `User` role on registration and set `DisplayName`
- show username in navbar after login
- allow editing avatar URL and display name in profile
- show email confirmation status with button

## Testing
- `dotnet build projects/projects.csproj -c Release` *(fails: dotnet not installed)*
- `dotnet test projects/projects.csproj` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68560f5060248323aa32bfca153e1db7