### PR TITLE
Fix leaderboard query and profile link

### DIFF
--- a/projects/Pages/Leaderboard/Index.cshtml.cs
+++ b/projects/Pages/Leaderboard/Index.cshtml.cs
@@ -23,16 +23,22 @@ namespace projects.Pages.Leaderboard
 
         public async Task OnGetAsync()
         {
-            Rows = await _context.GameWinStats
-                .Include(s => s.User)
-                .GroupBy(s => new { s.UserId, s.User })
-                .Select(g => new Row
+            var query = _context.GameWinStats
+                .GroupBy(s => s.UserId)
+                .Select(g => new
                 {
-                    User = g.Key.User,
+                    UserId = g.Key,
                     Wins = g.Sum(x => x.Wins)
                 })
                 .OrderByDescending(r => r.Wins)
-                .Take(100)
+                .Take(100);
+
+            Rows = await query
+                .Join(_context.Users, q => q.UserId, u => u.Id, (q, u) => new Row
+                {
+                    User = u,
+                    Wins = q.Wins
+                })
                 .AsNoTracking()
                 .ToListAsync();
         }

--- a/projects/Pages/Shared/_Layout.cshtml
+++ b/projects/Pages/Shared/_Layout.cshtml
@@ -40,7 +40,7 @@
                         @if (User.Identity?.IsAuthenticated ?? false)
                         {
                             <li class="nav-item">
-                                <span class="nav-link fw-bold">@User.Identity?.Name</span>
+                                <a class="nav-link fw-bold" asp-area="" asp-page="/Profile/Index">@User.Identity?.Name</a>
                             </li>
                             <li class="nav-item">
                                 <form asp-controller="Account" asp-action="Logout" method="post" class="d-inline">


### PR DESCRIPTION
## Summary
- join user data when building leaderboard to avoid invalid grouping
- link username in the header to profile page

## Testing
- `dotnet build projects.sln --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685617b16ef88323933c445aba8c5c59