### PR TITLE
Implement coin to premium exchange feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 10	Достижения (Achievements)       Значки за первые 10 побед, безошибочный раунд и т.д. [bearbones] (Models/Achievement.cs, Models/UserAchievement.cs, Servises/AchievementService.cs, Pages/Achievements/Index.cshtml)
 11	Глобальный и дружественный лидерборд    Топ-100 по победам, фильтр “друзья”. [bearbones] (Pages/Leaderboard/Index.cshtml)
 12	Магазин внутриигровых предметов	Скины досок/тем, подсказки, купить за обычные или донатные монеты. [bearbones] (Models/Item.cs, Models/UserItem.cs, Servises/ItemStoreService.cs, Pages/ItemStore/Index.cshtml)
-13	Обмен внутриигровых → донатных монет (ограниченный)	Лояльность free-to-play игрокам, баланс экономики.
+13      Обмен внутриигровых → донатных монет (ограниченный)     Лояльность free-to-play игрокам, баланс экономики. [bearbones] (Models/ExchangeTransaction.cs, Servises/CurrencyExchangeService.cs, Pages/Exchange/Index.cshtml)
 14	Матч-мейкинг PvP (опционально)	Подбор соперника по ELO, режим “битва умов”.
 15	Реальный-тайм чат и эмодзи в игре	SignalR; коммуникация повышает вовлечённость.
 16	Админ-панель	Управление играми, банами, предметами магазина, акциями.
@@ -91,3 +91,4 @@ Feature flags: включайте новые игры, магазин, PvP по�
 - Реализован глобальный лидерборд побед – **bearbones** (Pages/Leaderboard/Index.cshtml)
 - Реализованы ежедневные квесты – **bearbones** (Models/Quest.cs, Models/UserQuest.cs, Servises/QuestService.cs, Pages/Quests/Index.cshtml)
 - Добавлен магазин внутриигровых предметов – **bearbones** (Models/Item.cs, Models/UserItem.cs, Servises/ItemStoreService.cs, Pages/ItemStore/Index.cshtml)
+- Реализован обмен обычных монет на премиум – **bearbones** (Models/ExchangeTransaction.cs, Servises/CurrencyExchangeService.cs, Pages/Exchange/Index.cshtml)

--- a/projects/Migrations/20250621023000_AddExchangeTransactions.cs
+++ b/projects/Migrations/20250621023000_AddExchangeTransactions.cs
@@ -1,0 +1,49 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace projects.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExchangeTransactions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ExchangeTransactions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    CoinsSpent = table.Column<decimal>(type: "numeric", nullable: false),
+                    PremiumReceived = table.Column<decimal>(type: "numeric", nullable: false),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ExchangeTransactions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ExchangeTransactions_AspNetUsers_UserId",
+                        column: x => x.UserId,
+                        principalTable: "AspNetUsers",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ExchangeTransactions_UserId",
+                table: "ExchangeTransactions",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ExchangeTransactions");
+        }
+    }
+}

--- a/projects/Models/ApplicationDbContext.cs
+++ b/projects/Models/ApplicationDbContext.cs
@@ -22,6 +22,7 @@ namespace projects.Models
         public DbSet<UserQuest> UserQuests => Set<UserQuest>();
         public DbSet<Item> Items => Set<Item>();
         public DbSet<UserItem> UserItems => Set<UserItem>();
+        public DbSet<ExchangeTransaction> ExchangeTransactions => Set<ExchangeTransaction>();
 
         protected override void OnModelCreating(ModelBuilder builder)
         {
@@ -114,6 +115,15 @@ namespace projects.Models
                 .HasOne(ui => ui.Item)
                 .WithMany(i => i.UserItems)
                 .HasForeignKey(ui => ui.ItemId);
+
+            builder.Entity<ExchangeTransaction>()
+                .HasKey(e => e.Id);
+
+            builder.Entity<ExchangeTransaction>()
+                .HasOne<User>()
+                .WithMany()
+                .HasForeignKey(e => e.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
         }
     }
 }

--- a/projects/Models/ExchangeTransaction.cs
+++ b/projects/Models/ExchangeTransaction.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace projects.Models
+{
+    /// <summary>
+    /// Records conversion of regular coins to premium coins.
+    /// </summary>
+    public class ExchangeTransaction
+    {
+        public Guid Id { get; set; }
+        public Guid UserId { get; set; }
+        public decimal CoinsSpent { get; set; }
+        public decimal PremiumReceived { get; set; }
+        public DateTime CreatedAt { get; set; }
+    }
+}

--- a/projects/Pages/Exchange/Index.cshtml
+++ b/projects/Pages/Exchange/Index.cshtml
@@ -1,0 +1,19 @@
+@page
+@model projects.Pages.Exchange.IndexModel
+@{
+    ViewData["Title"] = "Exchange";
+}
+
+<h2>Exchange Coins to Premium</h2>
+
+@if(Model.Message != null){
+    <div class="alert alert-info">@Model.Message</div>
+}
+
+<form method="post">
+    <div class="form-group">
+        <label>Coins to exchange (must be multiple of 100)</label>
+        <input asp-for="Coins" class="form-control" />
+    </div>
+    <button type="submit" class="btn btn-primary mt-2">Exchange</button>
+</form>

--- a/projects/Pages/Exchange/Index.cshtml.cs
+++ b/projects/Pages/Exchange/Index.cshtml.cs
@@ -1,0 +1,49 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using projects.Models;
+using projects.Servises;
+
+namespace projects.Pages.Exchange
+{
+    [Authorize]
+    public class IndexModel : PageModel
+    {
+        private readonly CurrencyExchangeService _exchangeService;
+        private readonly UserManager<User> _userManager;
+
+        [BindProperty]
+        public decimal Coins { get; set; } = 100;
+        public string? Message { get; set; }
+
+        public IndexModel(CurrencyExchangeService exchangeService, UserManager<User> userManager)
+        {
+            _exchangeService = exchangeService;
+            _userManager = userManager;
+        }
+
+        public void OnGet()
+        {
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            var userIdStr = _userManager.GetUserId(User);
+            if (userIdStr == null)
+                return RedirectToPage();
+
+            try
+            {
+                var premium = await _exchangeService.ExchangeAsync(Guid.Parse(userIdStr), Coins);
+                Message = $"Received {premium} premium coins";
+            }
+            catch (Exception ex)
+            {
+                ModelState.AddModelError(string.Empty, ex.Message);
+            }
+
+            return Page();
+        }
+    }
+}

--- a/projects/Pages/Shared/_Layout.cshtml
+++ b/projects/Pages/Shared/_Layout.cshtml
@@ -41,6 +41,9 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-page="/Leaderboard/Index">Leaderboard</a>
                         </li>
+                        <li class="nav-item">
+                            <a class="nav-link text-dark" asp-area="" asp-page="/Exchange/Index">Exchange</a>
+                        </li>
                     </ul>
                     <ul class="navbar-nav">
                         @if (User.Identity?.IsAuthenticated ?? false)

--- a/projects/Program.cs
+++ b/projects/Program.cs
@@ -24,6 +24,7 @@ namespace projects
             builder.Services.AddScoped<AchievementService>();
             builder.Services.AddScoped<QuestService>();
             builder.Services.AddScoped<ItemStoreService>();
+            builder.Services.AddScoped<CurrencyExchangeService>();
             builder.Services.AddTransient<EmailSendler>();
             builder.Services.AddTransient<UserService>();
             builder.Services.AddHttpContextAccessor();

--- a/projects/Servises/CurrencyExchangeService.cs
+++ b/projects/Servises/CurrencyExchangeService.cs
@@ -1,0 +1,52 @@
+using Microsoft.EntityFrameworkCore;
+using projects.Models;
+
+namespace projects.Servises
+{
+    /// <summary>
+    /// Handles converting regular coins into premium coins with a daily limit.
+    /// </summary>
+    public class CurrencyExchangeService
+    {
+        private readonly ApplicationDbContext _context;
+        private const decimal ExchangeRate = 100m; // 100 coins -> 1 premium
+        private const decimal DailyLimit = 1000m; // max coins per day
+
+        public CurrencyExchangeService(ApplicationDbContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<decimal> ExchangeAsync(Guid userId, decimal coins)
+        {
+            if (coins <= 0) throw new ArgumentException("Amount must be positive", nameof(coins));
+            if (coins % ExchangeRate != 0) throw new InvalidOperationException($"Amount must be multiple of {ExchangeRate}");
+            var today = DateTime.UtcNow.Date;
+            var spentToday = await _context.ExchangeTransactions
+                .Where(t => t.UserId == userId && t.CreatedAt >= today)
+                .SumAsync(t => t.CoinsSpent);
+            if (spentToday + coins > DailyLimit)
+                throw new InvalidOperationException("Daily exchange limit exceeded");
+
+            var wallet = await _context.Wallets.FirstOrDefaultAsync(w => w.UserId == userId);
+            if (wallet == null || wallet.Balance < coins)
+                throw new InvalidOperationException("Not enough coins");
+
+            wallet.Balance -= coins;
+            var premium = coins / ExchangeRate;
+            wallet.PremiumBalance += premium;
+
+            _context.ExchangeTransactions.Add(new ExchangeTransaction
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                CoinsSpent = coins,
+                PremiumReceived = premium,
+                CreatedAt = DateTime.UtcNow
+            });
+
+            await _context.SaveChangesAsync();
+            return premium;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `ExchangeTransaction` model and migration
- create `CurrencyExchangeService` for coin to premium conversion
- expose new Exchange page with form
- register the service and link in layout
- document feature progress in README

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68561b2990a48323bc47fde44eef184e